### PR TITLE
fix deprecated Requiring React API imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
-
 import React, {
-  NativeModules,
   Component,
+} from 'react';
+
+import {
+  NativeModules,
   View,
   TouchableWithoutFeedback,
 } from 'react-native';


### PR DESCRIPTION
AS of RN0.26 requiring React API from react-native is deprecated 
