### PR TITLE
fix lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import {
 const FullScreen = NativeModules.FullScreen
 export default FullScreen;
 
-import _ from 'lodash';
+import debounce from 'debounce';
 
 export class ToggleView extends Component {
   constructor(props,context){
@@ -19,8 +19,8 @@ export class ToggleView extends Component {
     this.state = {
       focus:this.props.focus||true
     }
-    this.offFullScreen = _.debounce(FullScreen.offFullScreen,250);
-    this.delayHide = _.debounce(() => {
+    this.offFullScreen = debounce(FullScreen.offFullScreen,250);
+    this.delayHide = debounce(() => {
         FullScreen.onFullScreen();
         this.setState({focus:false});
     },this.props.delay || 3000);

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/Anthonyzou/react-native-full-screen/issues"
   },
-  "homepage": "https://github.com/Anthonyzou/react-native-full-screen#readme"
+  "homepage": "https://github.com/Anthonyzou/react-native-full-screen#readme",
+  "dependencies": {
+    "debounce": "^1.0.0"
+  }
 }


### PR DESCRIPTION
This was using `lodash`, and it wasn't even in `package.json`

I replaced it with the much lighter `debounce`, and put it in `package.json`
